### PR TITLE
Allow string paths for load and save

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PNGFiles"
 uuid = "f57f5aa1-a3ce-4bc8-8ab9-96f992907883"
 authors = ["Ian Butterworth", "Tomáš Drvoštěp"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/README.md
+++ b/README.md
@@ -16,14 +16,12 @@ pkg> add PNGFiles  # Press ']' to enter te Pkg REPL mode.
 ## Usage
 
 PNGFiles is not yet integrated into FileIO.
-For now, do this:
+For now, you can load png files using:
 
 ```jl
-using FileIO, PNGFiles
-fformat = File{DataFormat{:PNG}}("path/to/img.png")
-
-PNGFiles.save(fformat, rand(Gray, 100, 100))
-PNGFiles.load(fformat)
+using PNGFiles
+PNGFiles.save("path/to/img.png", rand(Gray, 100, 100))
+PNGFiles.load("path/to/img.png")
 ```
 
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,5 +1,6 @@
 """
     load(f::File{DataFormat{:PNG}})
+    load(f::String)
 
 Read a `.png` image from file `f`.
 Returns a matrix.
@@ -66,6 +67,7 @@ function load(f::File{DataFormat{:PNG}})
     close_png(fp)
     return transpose(buffer)
 end
+load(f::String) = load(File{DataFormat{:PNG}}(f))
 
 function _buffer_color_type(color_type, bit_depth)
     if color_type == PNG_COLOR_TYPE_GRAY
@@ -89,6 +91,8 @@ end
 """
     save(f::File{DataFormat{:PNG}}, image::AbstractArray
         [, compression_level::Integer=0, compression_strategy::Integer=3, filters::Integer=4,])
+    save(f::String, image::AbstractArray
+        [, compression_level::Integer=0, compression_strategy::Integer=3, filters::Integer=4,])
 
 Writes `image` as a png to file `f`.
 
@@ -111,7 +115,7 @@ function save(
         image::S,
         compression_level::Integer=Z_NO_COMPRESSION,
         compression_strategy::Integer=Z_RLE,
-        filters::Integer=PNG_FILTER_PAETH
+        filters::Integer=Int(PNG_FILTER_PAETH)
     ) where {
         T,
         S<:Union{AbstractMatrix,AbstractArray{T,3}}
@@ -188,6 +192,18 @@ function save(
 
     png_destroy_write_struct(Ref(png_ptr), Ref(info_ptr))
     close_png(fp)
+end
+function save(
+        f::String,
+        image::S,
+        compression_level::Integer=Z_NO_COMPRESSION,
+        compression_strategy::Integer=Z_RLE,
+        filters::Integer=Int(PNG_FILTER_PAETH)
+    ) where {
+        T,
+        S<:Union{AbstractMatrix,AbstractArray{T,3}}
+    }
+    return save(File{DataFormat{:PNG}}(f), image, compression_level, compression_strategy, filters)
 end
 
 function _write_image(buf::AbstractArray{T,2}, png_ptr::Ptr{Cvoid}, info_ptr::Ptr{Cvoid}) where {T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,6 @@ using Test
 using TestImages
 using Glob
 using PNGFiles: _prepare_buffer, load, save
-using FileIO: DataFormat, File
 
 logger = ConsoleLogger(stdout, Logging.Info)
 global_logger(logger)
@@ -117,7 +116,7 @@ edge_case_imgs = [
         @debug case
         @testset "$(case)" begin
             expected = collect(_prepare_buffer(image))
-            f = File{DataFormat{:PNG}}(joinpath(PNG_TEST_PATH, "test_img_$(case).png"))
+            f = joinpath(PNG_TEST_PATH, "test_img_$(case).png")
             @testset "write" begin
                 @test save(f, image) == 0
             end
@@ -135,7 +134,7 @@ edge_case_imgs = [
         @debug case
         @testset "$(case) throws" begin
             @test_throws exception save(
-                File{DataFormat{:PNG}}(joinpath(PNG_TEST_PATH, "test_img_err_$(case).png")),
+                joinpath(PNG_TEST_PATH, "test_img_err_$(case).png"),
                 image
             )
         end
@@ -144,7 +143,7 @@ edge_case_imgs = [
     for (case, func_in, image) in edge_case_imgs
         @debug case
         @testset "$(case)" begin
-            f = File{DataFormat{:PNG}}(joinpath(PNG_TEST_PATH, "test_img_$(case).png"))
+            f = joinpath(PNG_TEST_PATH, "test_img_$(case).png")
             @testset "write" begin
                 @test save(f, image) == 0
             end
@@ -163,11 +162,10 @@ edge_case_imgs = [
             case = splitpath(test_img_path)[end]
             @debug case
             @testset "$(case)" begin
-                f = File{DataFormat{:PNG}}(test_img_path)
-                global read_in = load(f)
+                global read_in = load(test_img_path)
                 @test read_in isa Matrix
                 path, ext = splitext(test_img_path)
-                @test save(File{DataFormat{:PNG}}(path * "_new" * ext), read_in) == 0
+                @test save("$(path)_new$(ext)", read_in) == 0
             end
         end
 


### PR DESCRIPTION
The need to use the FileIO entry methods seemed OTT when you know you're working with PNG's and wanted to use PNGFiles directly, so I just added methods for string file paths and switched over the tests to use those entry points (remove the FileIO dep from tests for now)