### PR TITLE
Remove FileIO API, move to ImageIO for FileIO integration 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,9 +9,9 @@ ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 libpng_jll = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
 
 [compat]
-CEnum = "^0.2"
-ImageCore = "^0.8"
-julia = "^1.3"
+CEnum = "0.2"
+ImageCore = "0.8"
+julia = "1.3"
 libpng_jll = "1.6.37"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -5,17 +5,11 @@ version = "0.1.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 libpng_jll = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
 
 [compat]
 CEnum = "^0.2"
-ColorTypes = "^0.9"
-FileIO = "^1.2"
-FixedPointNumbers = "^0.7"
 ImageCore = "^0.8"
 julia = "^1.3"
 libpng_jll = "1.6.37"

--- a/src/PNGFiles.jl
+++ b/src/PNGFiles.jl
@@ -2,14 +2,11 @@ module PNGFiles
 # Started as a fork of https://github.com/FugroRoames/LibPNG.jl
 
 using libpng_jll
-using FixedPointNumbers
-using FileIO: DataFormat, @format_str, Stream, File, filename, stream
 using ImageCore
 
 libpng_wrap_dir = joinpath(@__DIR__, "..", "gen", "libpng")
 using CEnum
 include(joinpath(libpng_wrap_dir, "ctypes.jl"))
-export Ctm, Ctime_t, Cclock_t
 include(joinpath(libpng_wrap_dir, "libpng_common.jl"))
 include(joinpath(libpng_wrap_dir, "libpng_api.jl"))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,3 @@
-using ColorTypes
-using FixedPointNumbers
 using Images: maxabsfinite
 using ImageCore
 using ImageMagick
@@ -224,7 +222,7 @@ edge_case_imgs = [
             ignore_gamma = (C == Gray) # It seems Imagemagick doesn't apply gamma correction to gray
             b = case_info.bit_depth
             @testset "$(case)" begin
-                global read_in_pngf = PNGFiles.load(fpath, ignore_gamma)
+                global read_in_pngf = PNGFiles.load(fpath, ignore_gamma = ignore_gamma)
                 @test read_in_pngf isa Matrix
 
                 path, ext = splitext(fpath)


### PR DESCRIPTION
I've set up https://github.com/JuliaIO/ImageIO.jl as a lazy-loader for PNGFiles and the future JPEGFiles, TIFFFiles etc.

It handles the *Files deps, so that a user would just need to install ImageIO, and we can add format support to ImageIO without requiring the user to install each new format package.

The additional time in loading & saving images with the ImageIO layer should be on the order of a few ns, so negligible

@Drvi If you're ok with this, I can merge into #5 given it's become more of a final polishing PR