### PR TITLE
Initial attempt to add palette support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.1.3"
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 IndirectArrays = "9b13fd28-a010-5f03-acff-a1bbcff69959"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 libpng_jll = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -6,11 +6,13 @@ version = "0.1.3"
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+IndirectArrays = "9b13fd28-a010-5f03-acff-a1bbcff69959"
 libpng_jll = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
 
 [compat]
 CEnum = "0.2"
 ImageCore = "0.8"
+IndirectArrays = "0.5"
 julia = "1.3"
 libpng_jll = "1.6.37"
 

--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ libpng_jll = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
 CEnum = "0.2"
 ImageCore = "0.8"
 IndirectArrays = "0.5"
+OffsetArrays = "1.0"
 julia = "1.3"
 libpng_jll = "1.6.37"
 

--- a/src/PNGFiles.jl
+++ b/src/PNGFiles.jl
@@ -1,9 +1,10 @@
 module PNGFiles
 # Started as a fork of https://github.com/FugroRoames/LibPNG.jl
 
-using libpng_jll
 using ImageCore
 using IndirectArrays
+using OffsetArrays
+using libpng_jll
 
 libpng_wrap_dir = joinpath(@__DIR__, "..", "gen", "libpng")
 using CEnum
@@ -12,7 +13,7 @@ include(joinpath(libpng_wrap_dir, "libpng_common.jl"))
 include(joinpath(libpng_wrap_dir, "libpng_api.jl"))
 
 include("wraphelpers.jl")
-include("io.jl")
 include("utils.jl")
+include("io.jl")
 
 end # module

--- a/src/PNGFiles.jl
+++ b/src/PNGFiles.jl
@@ -3,6 +3,7 @@ module PNGFiles
 
 using libpng_jll
 using ImageCore
+using IndirectArrays
 
 libpng_wrap_dir = joinpath(@__DIR__, "..", "gen", "libpng")
 using CEnum

--- a/src/io.jl
+++ b/src/io.jl
@@ -284,13 +284,13 @@ function _png_check_paletted(palette, bit_depth, image, check_bounds)
     if !(eltype(image) <: UInt8)
         throw(ArgumentError(
             "Elements of `image` are zero based indices to `pallete` " *
-            "and mu be represented as `UInt8`s",
+            "and must be represented as `UInt8`s"
         ))
     end
     if check_bounds && color_count <= maximum(image)
         throw(ArgumentError(
             "Maximum value in `image` is larger or equal to `length(palette)`. " *
-            "This would've resulted into an out of bounds indexing into `palette`.",
+            "This would've resulted into an out of bounds indexing into `palette`."
         ))
     end
 end

--- a/src/io.jl
+++ b/src/io.jl
@@ -154,7 +154,7 @@ function load(fpath::String; gamma::Union{Nothing,Float64}=nothing, expand_palet
     else
         # We got 0-based indices back from libpng and converting to 1-based could overflow UInt8.
         # Using UInt16 for index would cost us large part of the savings provided by IndirectArray.
-        return IndirectArray(buffer, OffsetArray(palette, 0:length(palette)-1))
+        return IndirectArray(buffer, OffsetArray(palette, -1))
     end
 end
 
@@ -205,7 +205,7 @@ output:
 - 3 channels Float  / Integer / Normed or RGB / BGR eltype   -> `PNG_COLOR_TYPE_RGB`
 - 4 channels Float  / Integer / Normed or ARGB / ABGR eltype -> `PNG_COLOR_TYPE_RGB_ALPHA`
 
-When `image` is an `IndirectArray` with up to 256 unique RGB colors, the result is encoded as a 
+When `image` is an `IndirectArray` with up to 256 unique RGB colors, the result is encoded as a
 "paletted image".
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,10 @@
+# A dummy struct used to easily collect alpha values for paletted images. It allows us to simply
+# call `pointer_from_objref` on a `Vector{_AlphaBuffer}`
+struct _AlphaBuffer
+    val::N0f8
+end
+
+
 function _inspect_png_read(fpath, gamma::Union{Nothing,Float64}=nothing)
     fp = open_png(fpath)
     png_ptr = create_read_struct()
@@ -95,7 +102,7 @@ function _inspect_png_read(fpath, gamma::Union{Nothing,Float64}=nothing)
         (height, width, num_channels),
         (color_type_orig, color_type),
         (bit_depth_orig, bit_depth),
-        (ignore_gamma, image_gamma[], screen_gamma),
+        (image_gamma[], screen_gamma),
         intent[],
         (white_x[], white_y[], red_x[], red_y[], green_x[], green_y[], blue_x[], blue_y[]),
         (interlace_type, n_passes),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,4 +51,6 @@ end
 end
 
 # Cleanup
-isdir(PNG_TEST_PATH) && rm(PNG_TEST_PATH, recursive = true)
+if !is_ci()
+    isdir(PNG_TEST_PATH) && rm(PNG_TEST_PATH, recursive = true)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,7 @@ end
 @testset "PNGFiles" begin
     include("test_invalid_inputs.jl")
     include("test_pngsuite.jl")
+    include("test_paletted_images.jl")
     include("test_synthetic_images.jl")
     include("test_testimages.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Logging
 using Glob
 using ImageCore
 using ImageMagick
+using IndirectArrays
 using Test
 using PNGFiles
 import PNGFiles._inspect_png_read

--- a/test/test_invalid_inputs.jl
+++ b/test/test_invalid_inputs.jl
@@ -14,3 +14,27 @@ for (case, exception, image) in invalid_imgs
         end
     end
 end
+
+
+invalid_paletted_imgs = [
+    ("palette_index_eltype_too_wide", Exception, rand(UInt16.(0:3), 127, 257), rand(RGB{N0f8}, 4)),
+    ("palette_index_too_few_dimensions", Exception, rand(UInt16.(0:3), 127), rand(RGB{N0f8}, 4)),
+    ("palette_index_out_of_bounds", Exception, collect(reshape(UInt8.(0:5), 2, 3)), rand(RGB{N0f8}, 3)),
+    ("palette_index_many_few_dimensions", Exception, rand(UInt16.(0:3), 127, 257, 3), rand(RGB{N0f8}, 4)),
+    ("palette_too_large", Exception, rand(UInt8, 127, 257), rand(RGB{N0f8}, 257)),
+    ("palette_eltype_too_wide", Exception, rand(UInt8.(0:3), 127, 257), rand(RGB{N0f16}, 4)),
+    ("palette_eltype_float", Exception, rand(UInt16.(0:3), 127, 257), rand(RGB, 4)),
+    ("palette_non_RGB_colorant", Exception, rand(UInt8.(0:3), 127, 257), rand(Gray{N0f8}, 3)),
+]
+
+@testset "invalid peletted inputs" begin
+for (case, exception, image, palette) in invalid_paletted_imgs
+        @testset "$(case) throws" begin
+            @test_throws exception PNGFiles.save(
+                joinpath(PNG_TEST_PATH, "test_img_err_$(case).png"),
+                image,
+                palette=palette
+            )
+        end
+    end
+end

--- a/test/test_invalid_inputs.jl
+++ b/test/test_invalid_inputs.jl
@@ -2,6 +2,11 @@ invalid_imgs = [
     ("too_few_dimensions", MethodError, rand(127)),
     ("too_many_channels", AssertionError, rand(127, 257, 5)),
     ("too_many_dimensions", MethodError, rand(127, 257, 3, 1)),
+    ("palette_too_large", ArgumentError, IndirectArray(rand(1:257, 127, 256), rand(RGB{N0f8}, 257))),
+    ("palette_index_too_few_dimensions", MethodError, IndirectArray(rand(1:4, 127), rand(RGB{N0f8}, 4))),
+    ("palette_index_too_many_dimensions", ArgumentError, IndirectArray(rand(1:4, 127, 256, 1), rand(RGB{N0f8}, 4))),
+    ("palette_eltype_too_wide", ArgumentError, IndirectArray(rand(1:4, 127, 256), rand(RGB{N0f16}, 4))),
+    ("palette_non_RGB_colorant", ArgumentError, IndirectArray(rand(1:4, 127, 256), rand(Gray{N0f8}, 4))),
 ]
 
 @testset "invalid inputs" begin
@@ -10,30 +15,6 @@ for (case, exception, image) in invalid_imgs
             @test_throws exception PNGFiles.save(
                 joinpath(PNG_TEST_PATH, "test_img_err_$(case).png"),
                 image
-            )
-        end
-    end
-end
-
-
-invalid_paletted_imgs = [
-    ("palette_index_eltype_too_wide", Exception, rand(UInt16.(0:3), 127, 257), rand(RGB{N0f8}, 4)),
-    ("palette_index_too_few_dimensions", Exception, rand(UInt16.(0:3), 127), rand(RGB{N0f8}, 4)),
-    ("palette_index_out_of_bounds", Exception, collect(reshape(UInt8.(0:5), 2, 3)), rand(RGB{N0f8}, 3)),
-    ("palette_index_many_few_dimensions", Exception, rand(UInt16.(0:3), 127, 257, 3), rand(RGB{N0f8}, 4)),
-    ("palette_too_large", Exception, rand(UInt8, 127, 257), rand(RGB{N0f8}, 257)),
-    ("palette_eltype_too_wide", Exception, rand(UInt8.(0:3), 127, 257), rand(RGB{N0f16}, 4)),
-    ("palette_eltype_float", Exception, rand(UInt16.(0:3), 127, 257), rand(RGB, 4)),
-    ("palette_non_RGB_colorant", Exception, rand(UInt8.(0:3), 127, 257), rand(Gray{N0f8}, 3)),
-]
-
-@testset "invalid peletted inputs" begin
-for (case, exception, image, palette) in invalid_paletted_imgs
-        @testset "$(case) throws" begin
-            @test_throws exception PNGFiles.save(
-                joinpath(PNG_TEST_PATH, "test_img_err_$(case).png"),
-                image,
-                palette=palette
             )
         end
     end

--- a/test/test_paletted_images.jl
+++ b/test/test_paletted_images.jl
@@ -24,7 +24,7 @@ expected_img(x::Matrix{<:AbstractRGB}) = convert(Array{RGB{N0f8}}, x)
             end
             @testset "read" begin
                 global read_in_pngf = PNGFiles.load(fpath)
-                @test read_in_pngf isa Matrix
+                @test typeof(read_in_pngf) <: AbstractMatrix
             end
             @testset "compare" begin
                 @test all(expected .≈ read_in_pngf)

--- a/test/test_paletted_images.jl
+++ b/test/test_paletted_images.jl
@@ -1,0 +1,41 @@
+synth_paletted_imgs = [
+    ("RGB_paletted", rand(UInt8, 127, 257), rand(RGB{N0f8}, 256)),
+    ("RGBA_paletted", rand(UInt8, 127, 257), rand(RGBA{N0f8}, 256)),
+]
+
+@testset "synthetic paletted images" begin
+    for (case, image, palette) in synth_paletted_imgs
+        @testset "$(case)" begin
+            expected = getindex.(Ref(palette), Int.(image) .+ 1)
+            fpath = joinpath(PNG_TEST_PATH, "test_img_$(case).png")
+            @testset "write" begin
+                @test PNGFiles.save(fpath, image, palette=palette) == 0
+            end
+            @testset "read" begin
+                global read_in_pngf = PNGFiles.load(fpath)
+                @test read_in_pngf isa Matrix
+            end
+            @testset "compare" begin
+                @test all(expected .≈ read_in_pngf)
+            end
+            global read_in_immag = _standardize_grayness(ImageMagick.load(fpath))
+            @testset "$(case): ImageMagick read type equality" begin
+                # The lena image is Grayscale saved as RGB...
+                @test eltype(_standardize_grayness(read_in_pngf)) == eltype(read_in_immag)
+            end
+            @testset "$(case): ImageMagick read values equality" begin
+                imdiff_val = imdiff(read_in_pngf, read_in_immag)
+                onfail(@test imdiff_val < 0.01) do
+                    PNGFiles._inspect_png_read(fpath)
+                    _add_debugging_entry(fpath, case, imdiff_val)
+                end
+            end
+            path, ext = splitext(fpath)
+            newpath = path * "_new" * ext
+            PNGFiles.save(newpath, read_in_pngf)
+            @testset "$(case): IO is idempotent" begin
+                @test all(read_in_pngf .≈ PNGFiles.load(newpath))
+            end
+        end
+    end
+end

--- a/test/test_paletted_images.jl
+++ b/test/test_paletted_images.jl
@@ -1,15 +1,26 @@
 synth_paletted_imgs = [
-    ("RGB_paletted", rand(UInt8, 127, 257), rand(RGB{N0f8}, 256)),
-    ("RGBA_paletted", rand(UInt8, 127, 257), rand(RGBA{N0f8}, 256)),
+    ("RGB_paletted", IndirectArray(rand(1:100, 127, 257), rand(RGB{N0f8}, 100))),
+    ("BRG_paletted", IndirectArray(rand(1:100, 127, 257), rand(BGR{N0f8}, 100))),
+    ("ARGB_paletted", IndirectArray(rand(1:100, 127, 257), rand(ARGB{N0f8}, 100))),
+    ("ABGR_paletted", IndirectArray(rand(1:100, 127, 257), rand(ABGR{N0f8}, 100))),
+    ("RGBA_paletted", IndirectArray(rand(1:100, 127, 257), rand(RGBA{N0f8}, 100))),
+    ("RGB_paletted_float", IndirectArray(rand(1:100, 127, 257), rand(RGB{Float64}, 100))),
+    ("BRG_paletted_float", IndirectArray(rand(1:100, 127, 257), rand(BGR{Float64}, 100))),
+    ("ARGB_paletted_float", IndirectArray(rand(1:100, 127, 257), rand(ARGB{Float64}, 100))),
+    ("ABGR_paletted_float", IndirectArray(rand(1:100, 127, 257), rand(ABGR{Float64}, 100))),
+    ("RGBA_paletted_float", IndirectArray(rand(1:100, 127, 257), rand(RGBA{Float64}, 100))),
 ]
 
+expected_img(x::Matrix{<:TransparentColor}) = convert(Array{RGBA{N0f8}}, x)
+expected_img(x::Matrix{<:AbstractRGB}) = convert(Array{RGB{N0f8}}, x)
+
 @testset "synthetic paletted images" begin
-    for (case, image, palette) in synth_paletted_imgs
+    for (case, image) in synth_paletted_imgs
         @testset "$(case)" begin
-            expected = getindex.(Ref(palette), Int.(image) .+ 1)
+            expected = expected_img(collect(image))
             fpath = joinpath(PNG_TEST_PATH, "test_img_$(case).png")
             @testset "write" begin
-                @test PNGFiles.save(fpath, image, palette=palette) == 0
+                @test PNGFiles.save(fpath, image) == 0
             end
             @testset "read" begin
                 global read_in_pngf = PNGFiles.load(fpath)

--- a/test/test_pngsuite.jl
+++ b/test/test_pngsuite.jl
@@ -58,7 +58,7 @@ parse_pngsuite(x::Symbol) = parse_pngsuite(String(x))
 
         @testset "$(case)" begin
             global read_in_pngf = PNGFiles.load(fpath, gamma = is_gray ? 1.0 : nothing)
-            @test read_in_pngf isa Matrix
+            @test typeof(read_in_pngf) <: AbstractMatrix
 
             path, ext = splitext(fpath)
             newpath = path * "_new" * ext
@@ -84,7 +84,7 @@ parse_pngsuite(x::Symbol) = parse_pngsuite(String(x))
             end
             if b >= 8 # ImageMagick.jl does not read in sub 8 bit images correctly
                 @testset "$(case): ImageMagick read values equality" begin
-                    imdiff_val = imdiff(read_in_pngf, read_in_immag)
+                    imdiff_val = imdiff(collect(read_in_pngf), read_in_immag)
                     onfail(@test imdiff_val <= get(imdiff_tolerance, case, 0.01)) do
                         PNGFiles._inspect_png_read(fpath)
                         _add_debugging_entry(fpath, case, imdiff_val)

--- a/test/test_synthetic_images.jl
+++ b/test/test_synthetic_images.jl
@@ -84,7 +84,7 @@ edge_case_imgs = [
             end
             @testset "read" begin
                 global read_in_pngf = PNGFiles.load(fpath)
-                @test read_in_pngf isa Matrix
+                @test typeof(read_in_pngf) <: AbstractMatrix
             end
             @testset "compare" begin
                 @test all(expected .≈ read_in_pngf)

--- a/test/test_testimages.jl
+++ b/test/test_testimages.jl
@@ -17,7 +17,7 @@ real_imgs = [
             end
             @testset "read" begin
                 global read_in_pngf = PNGFiles.load(fpath)
-                @test read_in_pngf isa Matrix
+                @test typeof(read_in_pngf) <: AbstractMatrix
             end
             @testset "compare" begin
                 @test all(expected .≈ read_in_pngf)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -2,6 +2,12 @@ onfail(body, x) = error("I might have overlooked something: $x")
 onfail(body, _::Test.Pass) = nothing
 onfail(body, _::Tuple{Test.Fail,T}) where {T} = body()
 
+function is_ci()
+    get(ENV, "TRAVIS", "") == "true" ||
+    get(ENV, "APPVEYOR", "") in ("true", "True") ||
+    get(ENV, "CI", "") in ("true", "True")
+end
+
 absdiff(x, y) = x > y ? x - y : y - x
 
 function imdiff(a, b)
@@ -165,4 +171,3 @@ sentinel_min(::Type{C}) where {C<:AbstractGray} = _sentinel_min(C, eltype(C))
 _sentinel_min(::Type{C},::Type{T}) where {C<:AbstractGray,T} = C(sentinel_min(T))
 sentinel_max(::Type{C}) where {C<:AbstractGray} = _sentinel_max(C, eltype(C))
 _sentinel_max(::Type{C},::Type{T}) where {C<:AbstractGray,T} = C(sentinel_max(T))
-


### PR DESCRIPTION
Allows saving of files using palette table
Example usage below:

```
using PNGFiles, Images

nclasses = 15
myArray = [UInt8.(mod(x+y, nclasses)) for x=1:640, y=1:480 ]
PNGFiles.save("myfile_pal.png", myArray, palette=colortable)

```