### PR TITLE
Generate cfunctions png_error_fn and png_warn_fn at runtime

### DIFF
--- a/src/PNGFiles.jl
+++ b/src/PNGFiles.jl
@@ -14,6 +14,8 @@ include(joinpath(libpng_wrap_dir, "libpng_api.jl"))
 
 const readcallback_c = Ref{Ptr{Cvoid}}(C_NULL)
 const writecallback_c = Ref{Ptr{Cvoid}}(C_NULL)
+const png_error_fn_c = Ref{Ptr{Cvoid}}(C_NULL)
+const png_warn_fn_c = Ref{Ptr{Cvoid}}(C_NULL)
 
 include("wraphelpers.jl")
 include("utils.jl")
@@ -22,6 +24,8 @@ include("io.jl")
 function __init__()
     readcallback_c[] = @cfunction(_readcallback, Cvoid, (png_structp, png_bytep, png_size_t));
     writecallback_c[] = @cfunction(_writecallback, Csize_t, (png_structp, png_bytep, png_size_t));
+    png_error_fn_c[] = @cfunction(png_error_handler, Cvoid, (Ptr{Cvoid}, Cstring))
+    png_warn_fn_c[] = @cfunction(png_warn_handler, Cvoid, (Ptr{Cvoid}, Cstring))
 end
 
 end # module

--- a/src/io.jl
+++ b/src/io.jl
@@ -258,7 +258,7 @@ function save(
     fp = ccall(:fopen, Ptr{Cvoid}, (Cstring, Cstring), fpath, "wb")
     fp == C_NULL && error("Could not open $(fpath) for writing")
 
-    png_ptr = create_write_struct(png_error_fn, png_warn_fn)
+    png_ptr = create_write_struct()
     info_ptr = create_info_struct(png_ptr)
 
     png_init_io(png_ptr, fp)
@@ -288,7 +288,7 @@ function save(
     @assert size(image, 3) <= 4
     iswritable(s) || throw(ArgumentError("write failed, IOStream is not writeable"))
 
-    png_ptr = create_write_struct(png_error_fn, png_warn_fn)
+    png_ptr = create_write_struct()
     info_ptr = create_info_struct(png_ptr)
     lock(s.lock)
     png_set_write_fn(png_ptr, s.handle, writecallback_c[], C_NULL)

--- a/src/wraphelpers.jl
+++ b/src/wraphelpers.jl
@@ -1,7 +1,5 @@
 png_error_handler(::Ptr{Cvoid}, msg::Cstring) = error("Png error: $(unsafe_string(msg))")
 png_warn_handler(::Ptr{Cvoid}, msg::Cstring) = @warn("Png warn: $(unsafe_string(msg))")
-const png_error_fn = @cfunction(png_error_handler, Cvoid, (Ptr{Cvoid}, Cstring))
-const png_warn_fn = @cfunction(png_warn_handler, Cvoid, (Ptr{Cvoid}, Cstring))
 
 # Compression strategy
 const Z_DEFAULT_STRATEGY = 0
@@ -45,7 +43,7 @@ function open_png(filename::String)
 end
 
 function create_read_struct()
-    png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, C_NULL, png_error_fn, png_warn_fn)
+    png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, C_NULL, png_error_fn_c[], png_warn_fn_c[])
     png_ptr == C_NULL && error("Failed to create png read struct")
     return png_ptr
 end
@@ -59,8 +57,8 @@ end
 close_png(fp::Ptr{Cvoid}) = ccall(:fclose, Cint, (Ptr{Cvoid},), fp)
 
 # Write functions
-function create_write_struct(png_error_fn::Ptr{Cvoid}, png_warn_fn::Ptr{Cvoid})
-    png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, C_NULL, png_error_fn, png_warn_fn)
+function create_write_struct()
+    png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, C_NULL, png_error_fn_c[], png_warn_fn_c[])
     png_ptr == C_NULL && error("Failed to create png write struct")
     return png_ptr
 end


### PR DESCRIPTION
Candidate fix for #15 (which may be more than "thread safety" as the title suggests)