### PR TITLE
Default to Z_BEST_SPEED instead of Z_NO_COMPRESSION

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -242,7 +242,7 @@ When `image` is an `IndirectArray` with up to 256 unique RGB colors, the result 
 function save(
     fpath::String,
     image::S;
-    compression_level::Integer = Z_NO_COMPRESSION,
+    compression_level::Integer = Z_BEST_SPEED,
     compression_strategy::Integer = Z_RLE,
     filters::Integer = Int(PNG_FILTER_PAETH),
     palette::Union{Nothing,AbstractVector{<:Union{RGB{N0f8},RGBA{N0f8}}}} = nothing,
@@ -274,7 +274,7 @@ end
 function save(
     s::IO,
     image::S;
-    compression_level::Integer = Z_NO_COMPRESSION,
+    compression_level::Integer = Z_BEST_SPEED,
     compression_strategy::Integer = Z_RLE,
     filters::Integer = Int(PNG_FILTER_PAETH),
     palette::Union{Nothing,AbstractVector{<:Union{RGB{N0f8},RGBA{N0f8}}}} = nothing,
@@ -303,7 +303,7 @@ function save(
 end
 
 function _save(png_ptr, info_ptr, image::S;
-    compression_level::Integer = Z_NO_COMPRESSION,
+    compression_level::Integer = Z_BEST_SPEED,
     compression_strategy::Integer = Z_RLE,
     filters::Integer = Int(PNG_FILTER_PAETH),
     palette::Union{Nothing,AbstractVector{<:Union{RGB{N0f8},RGBA{N0f8}}}} = nothing,


### PR DESCRIPTION
Quoting [Wikipedia](https://en.wikipedia.org/wiki/Portable_Network_Graphics), "The motivation for creating the PNG format was the realization, in early 1995, that the Lempel–Ziv–Welch (LZW) data compression algorithm used in the Graphics Interchange Format (GIF) format was patented by Unisys. "  Therefore, defaulting saving PNG-files without compression goes a bit against the original motivation of the format. I propose setting the default value for `compression_level` to `Z_BEST_SPEED` instead of `Z_NO_COMPRESSION`.

Makie has adopted ImageIO, but this caused a regression in the size of the saved files https://github.com/JuliaPlots/Makie.jl/issues/629.