### PR TITLE
Precompile load(::String)

### DIFF
--- a/src/PNGFiles.jl
+++ b/src/PNGFiles.jl
@@ -28,4 +28,11 @@ function __init__()
     png_warn_fn_c[] = @cfunction(png_warn_handler, Cvoid, (Ptr{Cvoid}, Cstring))
 end
 
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    @assert precompile(load, (String,))
+    # save is harder to usefully precompile because of the diversity of array types
+end
+VERSION >= v"1.4.2" && _precompile_() # https://github.com/JuliaLang/julia/pull/35378
+
 end # module


### PR DESCRIPTION
This takes a good fraction of a second to precompile, so it's worth doing.

Without it:
```julia
julia> using SnoopCompileCore, FileIO

julia> tinf = @snoopi tmin=0.005 load("/home/tim/src/vigra/src/examples/cameraman.png")
6-element Vector{Tuple{Float64,Core.MethodInstance}}:
 (0.00689387321472168, MethodInstance for setindex!(::Dict{Pkg.BinaryPlatforms.Platform,Dict{String,Any}}, ::Dict{String,Any}, ::Pkg.BinaryPlatforms.FreeBSD))
 (0.007667064666748047, MethodInstance for permutedims(::Matrix{ColorTypes.Gray{FixedPointNumbers.N0f8}}, ::Tuple{Int64,Int64}))
 (0.013384103775024414, MethodInstance for collect(::Base.Generator{Base.Generator{Base.OneTo{Int64},Base.var"#183#184"{Matrix{ColorTypes.Gray{FixedPointNumbers.N0f8}}}},typeof(pointer)}))
 (0.020144939422607422, MethodInstance for map(::Function, ::Base.Generator{Base.OneTo{Int64},Base.var"#183#184"{Matrix{ColorTypes.Gray{FixedPointNumbers.N0f8}}}}))
 (0.08893799781799316, MethodInstance for get!(::Requires.var"#1#2", ::Dict{Base.PkgId,Vector{Function}}, ::Base.PkgId))
 (0.3117191791534424, MethodInstance for load(::String))
```
The first "column" is the amount of time inference spent inferring the function, so it's about 0.3s. This PR gets rid of that and the total time for the first execution of `load` drops from 1.4s to 1.1s. (Obviously, it's far faster on later calls in the same session.)