### PR TITLE
Fix for changed colortype conversion behavior

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ julia = "1.3"
 libpng_jll = "1.6.37"
 
 [extras]
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -28,4 +29,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["Glob", "ImageMagick", "Logging", "Random", "Tar", "Test", "TestImages"]
+test = ["Downloads", "Glob", "ImageMagick", "Logging", "Random", "Tar", "Test", "TestImages"]

--- a/test/test_paletted_images.jl
+++ b/test/test_paletted_images.jl
@@ -11,8 +11,8 @@ synth_paletted_imgs = [
     ("RGBA_paletted_float", IndirectArray(rand(1:100, 127, 257), rand(RGBA{Float64}, 100))),
 ]
 
-expected_img(x::Matrix{<:TransparentColor}) = convert(Array{RGBA{N0f8}}, x)
-expected_img(x::Matrix{<:AbstractRGB}) = convert(Array{RGB{N0f8}}, x)
+expected_img(x::Matrix{<:TransparentColor}) = RGBA{N0f8}.(x)
+expected_img(x::Matrix{<:AbstractRGB}) = RGB{N0f8}.(x)
 
 @testset "synthetic paletted images" begin
     for (case, image) in synth_paletted_imgs

--- a/test/test_pngsuite.jl
+++ b/test/test_pngsuite.jl
@@ -1,4 +1,4 @@
-using Tar
+using Tar, Downloads
 
 PNG_SUITE_DIR = "PngSuite"
 PNG_SUITE_PATH = joinpath(PNG_TEST_PATH, PNG_SUITE_DIR)
@@ -29,7 +29,7 @@ const imdiff_tolerance = Dict(
 
 if !isdir(PNG_SUITE_PATH)
     mkdir(PNG_SUITE_PATH)
-    download("https://github.com/JuliaIO/PNG.jl/releases/download/PngSuite-2017jul19/PngSuite-2017jul19.tar.gz", PNG_SUITE_FILE)
+    Downloads.download("https://github.com/JuliaIO/PNG.jl/releases/download/PngSuite-2017jul19/PngSuite-2017jul19.tar.gz", PNG_SUITE_FILE)
     Tar.extract(PNG_SUITE_FILE, PNG_SUITE_PATH)
     rm(PNG_SUITE_FILE)
 end
@@ -62,9 +62,9 @@ parse_pngsuite(x::Symbol) = parse_pngsuite(String(x))
 
             path, ext = splitext(fpath)
             newpath = path * "_new" * ext
-            
+
             open(io->PNGFiles.save(io, read_in_pngf), newpath, "w") #test IO method
-            @test PNGFiles.save(newpath, read_in_pngf) == 0 
+            @test PNGFiles.save(newpath, read_in_pngf) == 0
             global read_in_immag = _standardize_grayness(ImageMagick.load(fpath))
 
             @testset "$(case): PngSuite/ImageMagick read type equality" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -23,10 +23,10 @@ _convert(C, T, xs::AbstractArray) =
 _convert(C, T, xs::AbstractMatrix) = collect(colorview(C, collect(reinterpret(T, collect(xs)))))
 
 _standardize_grayness(x) = x
-_standardize_grayness(x::AbstractArray{<:Gray{Bool}}) = convert(Array{Gray{N0f8}}, x)
+_standardize_grayness(x::AbstractArray{<:Gray{Bool}}) = Gray{N0f8}.(x)
 _standardize_grayness(x::AbstractArray{<:RGB}) = all(red.(x) .≈ green.(x) .≈ blue.(x)) ? Gray.(red.(x)) : x
 _standardize_grayness(x::AbstractArray{<:RGBA}) = all(red.(x) .≈ green.(x) .≈ blue.(x)) ?
-    convert(Array{GrayA}, colorview(GrayA, red.(x), alpha.(x))) :
+    GrayA.(colorview(GrayA, red.(x), alpha.(x))) :
     x
 
 
@@ -40,10 +40,10 @@ function plotdiffs(p, i)
     --------------|---------------|----------------------|---------------------
     ...
     """
-    _p = convert.(RGBA{Float64}, p)
+    _p = RGBA{Float64}.(p)
     __p = collect(channelview(_p))
     __p[4, :, :] .= 0.0
-    _i = convert.(RGBA{Float64}, i)
+    _i = RGBA{Float64}.(i)
     __i = collect(channelview(_i))
     __i[4, :, :] .= 1.0 # make the difference in alpha be 1 so it is visible
     d = collect(colorview(RGBA{Float64}, absdiff.(__p, __i)))


### PR DESCRIPTION
As seen in #25, the conversion of colortype arrays has changed behavior and was causing both warnings and failures

@Drvi does this look right to you?

We probably want to merge this before #25 and rebase that