### PR TITLE
Save to iobuffer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ julia = "1.3"
 libpng_jll = "1.6.37"
 
 [extras]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
@@ -29,4 +30,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["Downloads", "Glob", "ImageMagick", "Logging", "Random", "Tar", "Test", "TestImages"]
+test = ["Downloads", "Glob", "ImageMagick", "Logging", "Random", "Tar", "Test", "TestImages", "Base64"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Ian Butterworth", "Tomáš Drvoštěp"]
 version = "0.3.2"
 
 [deps]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 IndirectArrays = "9b13fd28-a010-5f03-acff-a1bbcff69959"
@@ -19,7 +20,6 @@ julia = "1.3"
 libpng_jll = "1.6.37"
 
 [extras]
-Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
@@ -30,4 +30,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["Downloads", "Glob", "ImageMagick", "Logging", "Random", "Tar", "Test", "TestImages", "Base64"]
+test = ["Downloads", "Glob", "ImageMagick", "Logging", "Random", "Tar", "Test", "TestImages"]

--- a/gen/libpng/libpng_api.jl
+++ b/gen/libpng/libpng_api.jl
@@ -365,7 +365,7 @@ function png_get_error_ptr(png_ptr)
 end
 
 function png_set_write_fn(png_ptr, io_ptr, write_data_fn, output_flush_fn)
-    ccall((:png_set_write_fn, libpng), Cvoid, (png_structrp, png_voidp, png_rw_ptr, png_flush_ptr), png_ptr, io_ptr, write_data_fn, output_flush_fn)
+    ccall((:png_set_write_fn, libpng), Cvoid, (png_structrp, Any, png_rw_ptr, png_flush_ptr), png_ptr, io_ptr, write_data_fn, output_flush_fn)
 end
 
 function png_set_read_fn(png_ptr, io_ptr, read_data_fn)

--- a/src/PNGFiles.jl
+++ b/src/PNGFiles.jl
@@ -1,6 +1,7 @@
 module PNGFiles
 # Started as a fork of https://github.com/FugroRoames/LibPNG.jl
 
+using Base64
 using ImageCore
 using IndirectArrays
 using OffsetArrays

--- a/src/io.jl
+++ b/src/io.jl
@@ -307,7 +307,7 @@ function save(
     png_ptr = create_write_struct()
     info_ptr = create_info_struct(png_ptr)
     maybe_lock(s) do
-        png_set_write_fn(png_ptr, s.handle, writecallback_c[], C_NULL)
+        png_set_write_fn(png_ptr, s, writecallback_c[], C_NULL)
 
         _save(png_ptr, info_ptr, image,
             compression_level=compression_level,
@@ -404,7 +404,8 @@ end
 
 function _writecallback(png_ptr::png_structp, data::png_bytep, length::png_size_t)::Csize_t
     a = png_get_io_ptr(png_ptr)
-    return ccall(:ios_write, Csize_t, (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t), a, data, length)
+    io = unsafe_pointer_to_objref(a)
+    unsafe_write(io, data, length)
 end
 
 function _write_image(buf::AbstractArray{T,2}, png_ptr::Ptr{Cvoid}, info_ptr::Ptr{Cvoid}) where {T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,7 @@ end
     include("test_paletted_images.jl")
     include("test_synthetic_images.jl")
     include("test_testimages.jl")
+    include("test_io.jl")
 end
 
 # Cleanup

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -1,0 +1,29 @@
+using TestImages, Base64
+
+test_name, test_image = first(
+    first(splitext(img_name)) => testimage(img_name)
+    for img_name
+    in TestImages.remotefiles
+    if endswith(img_name, ".png")
+)
+
+
+@testset "IOBuffer" begin
+    @test test_image == let
+        b = IOBuffer()
+        PNGFiles.save(b, test_image)
+        seek(b, 0)
+        PNGFiles.load(b)
+    end
+end
+
+@testset "Base64EncodedPipe" begin
+    # Waiting on a release which includes "https://github.com/JuliaLang/julia/pull/37520/files"
+    @test_broken test_image == let
+        io = Base64EncodePipe(IOBuffer())
+        PNGFiles.save(io, test_image)
+        decoded = IOBuffer(base64decode(take!(io)))
+        PNGFiles.load(decoded)
+    end
+end
+

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -17,12 +17,12 @@ test_name, test_image = first(
     end
 end
 
-@testset "Base64EncodedPipe" begin
-    # Waiting on a release which includes "https://github.com/JuliaLang/julia/pull/37520/files"
-    @test_broken test_image == let
+@testset "Base64EncodePipe" begin
+    @test test_image == let
         io = Base64EncodePipe(IOBuffer())
         PNGFiles.save(io, test_image)
-        decoded = IOBuffer(base64decode(take!(io)))
+        close(io)
+        decoded = IOBuffer(base64decode(take!(io.io)))
         PNGFiles.load(decoded)
     end
 end


### PR DESCRIPTION
This is an attempt to address #22. The `save` specifies the destination must be `::IO`, which are all supposed to implement  `unsafe_write`, so use that instead of asking for the file handle. This allows writing to `IOBuffer`, but `Base64EncodePipe` still needs a release of Julia with JuliaLang/Julia#37520. The corresponding test is marked broken for now.