### PR TITLE
bypass lock for IOContext

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -35,6 +35,7 @@ maybe_lock(f, io::IO) = lock(f, io)
 maybe_lock(f, io::IOStream) = f()
 maybe_lock(f, io::IOBuffer) = f()
 maybe_lock(f, io::Base64EncodePipe) = f()
+maybe_lock(f, io::IOContext) = maybe_lock(f, io.io)
 
 if VERSION < v"1.6.0-DEV.1652"
     _iswritable(x) = Base.iswritable(x)


### PR DESCRIPTION
This "fixes" the error that Pluto raises (with ImageIO only) when trying to display an image, e.g., `img = rand(RGB{N0f8}, 4, 4)`:

```julia
      From worker 2:	Errors encountered while saving nothing.
      From worker 2:	All errors:
      From worker 2:	===========================================
      From worker 2:	MethodError: no method matching lock(::PNGFiles.var"#13#14"{Int64, Int64, Int64, Nothing, IOContext{IOBuffer}, Matrix{ColorTypes.RGB{FixedPointNumbers.N0f8}}, Ptr{Nothing}, Ptr{Nothing}}, ::IOContext{IOBuffer})
      From worker 2:	Closest candidates are:
      From worker 2:	  lock(::Any, !Matched::Base.GenericCondition) at condition.jl:78
      From worker 2:	  lock(::Any, !Matched::Base.AbstractLock) at lock.jl:184
      From worker 2:	  lock(::Any, !Matched::WeakKeyDict) at weakkeydict.jl:76
      From worker 2:	===========================================
      From worker 2:	ArgumentError: Package QuartzImageIO not found in current path:
      From worker 2:	- Run `import Pkg; Pkg.add("QuartzImageIO")` to install the QuartzImageIO package.
      From worker 2:
      From worker 2:	===========================================
      From worker 2:	ArgumentError: Package ImageMagick not found in current path:
      From worker 2:	- Run `import Pkg; Pkg.add("ImageMagick")` to install the ImageMagick package.
      From worker 2:
      From worker 2:	===========================================
      From worker 2:	MethodError: no method matching save(::FileIO.Stream{FileIO.DataFormat{:PNG}, IOContext{IOBuffer}}, ::Matrix{ColorTypes.RGB{FixedPointNumbers.N0f8}}; mapi=ImageShow.var"#14#16"())
      From worker 2:	Closest candidates are:
      From worker 2:	  save(!Matched::FileIO.File{FileIO.DataFormat{:PNG}}, ::Any) at /Users/jc/.julia/packages/FileIO/TyKdX/src/mimesave.jl:5 got unsupported keyword argument "mapi"
      From worker 2:	  save(!Matched::FileIO.File{FileIO.DataFormat{:SVG}}, ::Any) at /Users/jc/.julia/packages/FileIO/TyKdX/src/mimesave.jl:15 got unsupported keyword argument "mapi"
      From worker 2:	  save(!Matched::FileIO.File{FileIO.DataFormat{:PDF}}, ::Any) at /Users/jc/.julia/packages/FileIO/TyKdX/src/mimesave.jl:25 got unsupported keyword argument "mapi"
      From worker 2:	  ...
      From worker 2:	===========================================
      From worker 2:
      From worker 2:	Fatal error:
```

with this method, the image is now displayed appropriately in Pluto.

cc: @fonsp