### PR TITLE
Fixed issue with debug logging in file loading

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -180,7 +180,6 @@ function _load(png_ptr, info_ptr; gamma::Union{Nothing,Float64}=nothing, expand_
 
     @debug(
         "Read PNG info:",
-        fpath,
         height,
         width,
         color_type_orig,


### PR DESCRIPTION
Debug logging call referenced an unknown variable and threw an error. It doesn't impact functionality, just produces significant output that is unnecessary.