### PR TITLE
test: lock test dependency ImageMagick_jll version to v6.9.10-12+3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,8 @@ libpng_jll = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
 [compat]
 CEnum = "0.2, 0.3, 0.4"
 ImageCore = "0.8, 0.9"
+# TODO(johnnychen94): remove direct ImageMagick_jll dependency after https://github.com/JuliaIO/ImageMagick.jl/issues/206 is fixed
+ImageMagick_jll = "= 6.9.10"
 IndirectArrays = "0.5, 1.0"
 OffsetArrays = "1.0"
 julia = "1.3"
@@ -23,6 +25,7 @@ libpng_jll = "1.6.37"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
+ImageMagick_jll = "c73af94c-d91f-53ed-93a7-00f77d67a9d7"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
@@ -30,4 +33,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["Downloads", "Glob", "ImageMagick", "Logging", "Random", "Tar", "Test", "TestImages"]
+test = ["Downloads", "Glob", "ImageMagick", "ImageMagick_jll", "Logging", "Random", "Tar", "Test", "TestImages"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,7 +41,16 @@ function _add_debugging_entry(fpath, case, imdiff_val=missing)
     end
 end
 
+function ensure_imagemagick()
+    # ImageMagick backend itself might be broken
+    # https://github.com/JuliaIO/ImageMagick.jl/issues/206
+    tmpfile = joinpath(PNG_TEST_PATH, "tmp.png")
+    img = Gray{N0f8}.(reshape(collect(0.0:0.01:0.49), 5, 10))
+    ImageMagick.save(tmpfile, img)
+    @test ImageMagick.load(tmpfile) == img
+end
 
+ensure_imagemagick()
 @testset "PNGFiles" begin
     include("test_invalid_inputs.jl")
     include("test_pngsuite.jl")


### PR DESCRIPTION
The latest ImageMagick_jll version v6.9.12-0 is currently broken (https://github.com/JuliaIO/ImageMagick.jl/issues/206). This commit temporarily locks its version so that future devs to PNGFiles are not affected.