### PR TITLE
Simplifications, more debug

### DIFF
--- a/gen/libpng/libpng_api.jl
+++ b/gen/libpng/libpng_api.jl
@@ -1,4 +1,9 @@
-## TODO: pending https://github.com/JuliaLang/julia/issues/29420
+##############################################
+# This file has been automatically generated #
+# Do not edit !                              #
+##############################################
+
+# TODO: pending https://github.com/JuliaLang/julia/issues/29420
 
 const PNGCAPI = nothing
 const PNG_BYTES_TO_CHECK = 8

--- a/gen/libpng/prologue.jl
+++ b/gen/libpng/prologue.jl
@@ -1,4 +1,9 @@
-## TODO: pending https://github.com/JuliaLang/julia/issues/29420
+##############################################
+# This file has been automatically generated #
+# Do not edit !                              #
+##############################################
+
+# TODO: pending https://github.com/JuliaLang/julia/issues/29420
 
 const PNGCAPI = nothing
 const PNG_BYTES_TO_CHECK = 8

--- a/src/io.jl
+++ b/src/io.jl
@@ -101,7 +101,7 @@ function _load(png_ptr, info_ptr; gamma::Union{Nothing,Float64}=nothing, expand_
     if valid_bKGD
         backgroundp = png_color_16p()
         if png_get_bKGD(png_ptr, info_ptr, Ptr{png_color_16p}(backgroundp)) != 0
-            png_set_background(png_ptr, backgroundp, PNG_BACKGROUND_GAMMA_FILE, 1, 1.)
+            png_set_background(png_ptr, backgroundp, PNG_BACKGROUND_GAMMA_FILE, 1, 1.0)
         end
     end
 


### PR DESCRIPTION
- some simplifications reading `PNG_INFO_...` flags, avoids further `png_get_valid` calls.
- add a message saying that `libpng_api.jl` is auto-generated
- added checks on `valid_bKGD` and `valid_PLTE`
- simplify `png_set_gamma` logic (strictly equivalent)
- more debugging info when `JULIA_DEBUG=PNGFiles` is set