### PR TITLE
only run benchmark on 'run benchmark' label

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   Benchmark:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'run benchmark')
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest


### PR DESCRIPTION
It's sometimes unnecessary to run the comprehensive benchmark test.