### PR TITLE
collect palatte to CPU array with valid pointer

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -620,11 +620,12 @@ function _get_color_type(
     error("Number of dimensions $(N) in image not supported (only 2D or 3D Arrays are expected).")
 end
 
-_standardize_palette(p::AbstractVector{<:RGB}) = p
-_standardize_palette(p::AbstractVector{<:AbstractRGB}) = RGB.(p)
-_standardize_palette(p::AbstractVector{<:RGB{<:AbstractFloat}}) = RGB{N0f8}.(p)
-_standardize_palette(p::AbstractVector{<:AbstractRGB{<:AbstractFloat}}) = RGB{N0f8}.(p)
-_standardize_palette(p::OffsetArray) = _standardize_palette(parent(p))
+_standardize_palette(p::AbstractVector) = _enforce_dense_cpu_array(__standardize_palette(p))
+__standardize_palette(p::AbstractVector{<:RGB}) = p
+__standardize_palette(p::AbstractVector{<:AbstractRGB}) = RGB.(p)
+__standardize_palette(p::AbstractVector{<:RGB{<:AbstractFloat}}) = RGB{N0f8}.(p)
+__standardize_palette(p::AbstractVector{<:AbstractRGB{<:AbstractFloat}}) = RGB{N0f8}.(p)
+__standardize_palette(p::OffsetArray) = __standardize_palette(parent(p))
 
 _palette_alpha(p::OffsetArray) where {T} = _palette_alpha(collect(p))
 _palette_alpha(p::AbstractVector{<:TransparentRGB{T,N0f8}}) where {T} = alpha.(p)

--- a/test/test_various_array_types.jl
+++ b/test/test_various_array_types.jl
@@ -52,4 +52,14 @@ using OffsetArrays
             end
         end
     end
+
+    @testset "indexed image with special palatte type" begin
+        index = rand(1:5, 3, 4)
+        palatte = colorview(RGB{N0f8}, rand(UInt8, 3, 5))
+        img = IndirectArray(index, palatte)
+        ref = _load_and_save(IOBuffer(), collect(img))
+        actual = _load_and_save(IOBuffer(), img)
+        @test ref == actual
+        @test actual isa IndirectArray{RGB{N0f8}, 2}
+    end
 end


### PR DESCRIPTION
This currently doesn't work:

```julia
index = rand(1:5, 3, 4)
palatte = colorview(RGB{N0f8}, rand(UInt8, 3, 5))
img = IndirectArray(index, palatte)
```

```julia
julia> PNGFiles.save(IOBuffer(), img)
ERROR: conversion to pointer not defined for SubArray{UInt8, 2, Matrix{UInt8}, Tuple{ImageCore.ColorChanPerm{3}, Base.Slice{Base.OneTo{Int64}}}, false}
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:33
  [2] unsafe_convert(#unused#::Type{Ptr{UInt8}}, a::SubArray{UInt8, 2, Matrix{UInt8}, Tuple{ImageCore.ColorChanPerm{3}, Base.Slice{Base.OneTo{Int64}}}, false})
    @ Base ./pointer.jl:67
  [3] unsafe_convert(#unused#::Type{Ptr{RGB{N0f8}}}, a::Base.ReinterpretArray{RGB{N0f8}, 1, UInt8, SubArray{UInt8, 2, Matrix{UInt8}, Tuple{ImageCore.ColorChanPerm{3}, Base.Slice{Base.OneTo{Int64}}}, false}, true})
    @ Base ./reinterpretarray.jl:315
  [4] unsafe_convert(#unused#::Type{Ptr{PNGFiles.png_color_struct}}, a::Base.ReinterpretArray{RGB{N0f8}, 1, UInt8, SubArray{UInt8, 2, Matrix{UInt8}, Tuple{ImageCore.ColorChanPerm{3}, Base.Slice{Base.OneTo{Int64}}}, false}, true})
    @ Base ./pointer.jl:66
  [5] png_set_PLTE(png_ptr::Ptr{Nothing}, info_ptr::Ptr{Nothing}, palette::Base.ReinterpretArray{RGB{N0f8}, 1, UInt8, SubArray{UInt8, 2, Matrix{UInt8}, Tuple{ImageCore.ColorChanPerm{3}, Base.Slice{Base.OneTo{Int64}}}, false}, true}, num_palette::Int64)
    @ PNGFiles ~/Documents/Julia/PNGFiles.jl/gen/libpng/libpng_api.jl:1010
  [6] _save(png_ptr::Ptr{Nothing}, info_ptr::Ptr{Nothing}, image::IndirectArray{RGB{N0f8}, 2, Int64, Matrix{Int64}, Base.ReinterpretArray{RGB{N0f8}, 1, UInt8, SubArray{UInt8, 2, Matrix{UInt8}, Tuple{ImageCore.ColorChanPerm{3}, Base.Slice{Base.OneTo{Int64}}}, false}, true}}; compression_level::Int64, compression_strategy::Int64, filters::Int64, file_gamma::Nothing, background::Nothing)
    @ PNGFiles ~/Documents/Julia/PNGFiles.jl/src/io.jl:451
  [7] (::PNGFiles.var"#9#10"{Int64, Int64, Int64, Nothing, Nothing, IOBuffer, IndirectArray{RGB{N0f8}, 2, Int64, Matrix{Int64}, Base.ReinterpretArray{RGB{N0f8}, 1, UInt8, SubArray{UInt8, 2, Matrix{UInt8}, Tuple{ImageCore.ColorChanPerm{3}, Base.Slice{Base.OneTo{Int64}}}, false}, true}}, Ptr{Nothing}, Ptr{Nothing}})()
    @ PNGFiles ~/Documents/Julia/PNGFiles.jl/src/io.jl:402
  [8] maybe_lock(f::PNGFiles.var"#9#10"{Int64, Int64, Int64, Nothing, Nothing, IOBuffer, IndirectArray{RGB{N0f8}, 2, Int64, Matrix{Int64}, Base.ReinterpretArray{RGB{N0f8}, 1, UInt8, SubArray{UInt8, 2, Matrix{UInt8}, Tuple{ImageCore.ColorChanPerm{3}, Base.Slice{Base.OneTo{Int64}}}, false}, true}}, Ptr{Nothing}, Ptr{Nothing}}, io::IOBuffer)
    @ PNGFiles ~/Documents/Julia/PNGFiles.jl/src/io.jl:62
  [9] save(s::IOBuffer, image::IndirectArray{RGB{N0f8}, 2, Int64, Matrix{Int64}, Base.ReinterpretArray{RGB{N0f8}, 1, UInt8, SubArray{UInt8, 2, Matrix{UInt8}, Tuple{ImageCore.ColorChanPerm{3}, Base.Slice{Base.OneTo{Int64}}}, false}, true}}; compression_level::Int64, compression_strategy::Int64, filters::Int64, file_gamma::Nothing, background::Nothing)
    @ PNGFiles ~/Documents/Julia/PNGFiles.jl/src/io.jl:397
 [10] save(s::IOBuffer, image::IndirectArray{RGB{N0f8}, 2, Int64, Matrix{Int64}, Base.ReinterpretArray{RGB{N0f8}, 1, UInt8, SubArray{UInt8, 2, Matrix{UInt8}, Tuple{ImageCore.ColorChanPerm{3}, Base.Slice{Base.OneTo{Int64}}}, false}, true}})
    @ PNGFiles ~/Documents/Julia/PNGFiles.jl/src/io.jl:389
 [11] top-level scope
    @ REPL[26]:1
```