### PR TITLE
support Gray{Bool} array

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PNGFiles"
 uuid = "f57f5aa1-a3ce-4bc8-8ab9-96f992907883"
 authors = ["Ian Butterworth", "Tomáš Drvoštěp"]
-version = "0.3.15"
+version = "0.3.16"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/io.jl
+++ b/src/io.jl
@@ -553,6 +553,7 @@ _prepare_buffer(x::AbstractMatrix{<:T}) where {T<:Colorant{<:Normed}} = x
 _prepare_buffer(x::AbstractMatrix{<:T}) where {T<:UInt8} =  reinterpret(Gray{N0f8}, x)
 _prepare_buffer(x::AbstractMatrix{<:T}) where {T<:UInt16} = reinterpret(Gray{N0f16}, x)
 _prepare_buffer(x::AbstractMatrix{<:T}) where {T<:Normed} = reinterpret(Gray{T}, x)
+_prepare_buffer(x::AbstractMatrix{<:T}) where {T<:Gray{Bool}} =  Gray{N0f8}.(x)
 _prepare_buffer(x::AbstractMatrix{<:T}) where {T<:Gray{<:AbstractFloat}} =  Gray{N0f8}.(x)
 _prepare_buffer(x::AbstractMatrix{<:T}) where {T<:GrayA{<:AbstractFloat}} = GrayA{N0f8}.(x)
 _prepare_buffer(x::AbstractMatrix{<:T}) where {T<:RGB{<:AbstractFloat}} =   RGB{N0f8}.(x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,6 +6,7 @@ _get_bit_depth(img::AbstractArray{T}) where {T<:Normed} = __get_bit_depth(T)
 # __get_bit_depth(::Type{Normed{T,1}}) where T = 1  # TODO: write 1 bit-depth images
 # __get_bit_depth(::Type{Normed{T,2}}) where T = 2  # TODO: write 2 bit-depth images
 # __get_bit_depth(::Type{Normed{T,4}}) where T = 4  # TODO: write 4 bit-depth images
+__get_bit_depth(::Type{Bool}) = 8  # TODO: write 1 bit-depth images
 __get_bit_depth(::Type{Normed{T,8}}) where T = 8
 __get_bit_depth(::Type{Normed{T,16}}) where T = 16
 __get_bit_depth(::Type{Normed{T,N}}) where {T,N} = ifelse(N <= 8, 8, 16)

--- a/test/test_images/synth_images.jl
+++ b/test/test_images/synth_images.jl
@@ -34,6 +34,7 @@ synth_imgs = [
     "RGB" => rand(RGB, 127, 257),
     "RGBA" => rand(RGBA, 127, 257),
     "ARGB32" => reinterpret(ARGB32, rand(UInt32, 127, 257)),
+    "Gray-Bool" => rand(Gray{Bool}, 127, 257),
     "Gray-N0f8" => rand(Gray{N0f8}, 127, 257),
     "GrayA-N0f8" => rand(GrayA{N0f8}, 127, 257),
     "RGB-N0f8" => rand(RGB{N0f8}, 127, 257),


### PR DESCRIPTION
This just adds two missing methods, loading the image back is still `Gray{N0f8}` as 1bit encoding is not yet supported.