### PR TITLE
Change include to use a relative path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,4 +35,6 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
       - uses: julia-actions/julia-runtest@latest
+        env:
+          JULIA_DEBUG: loading
       - uses: julia-actions/julia-processcoverage@v1

--- a/src/PNGFiles.jl
+++ b/src/PNGFiles.jl
@@ -7,7 +7,7 @@ using IndirectArrays
 using OffsetArrays
 using libpng_jll
 
-libpng_wrap_dir = joinpath(@__DIR__, "..", "gen", "libpng")
+libpng_wrap_dir = joinpath("..", "gen", "libpng")
 using CEnum
 include(joinpath(libpng_wrap_dir, "libpng_api.jl"))
 


### PR DESCRIPTION
Investigates a debug warning of 
```
┌ Debug: Missing @depot tag for include dependencies in cache file /home/runner/.julia/compiled/v1.11/PNGFiles/yIZEc_0dQEY.ji.
│   srcfiles =
│    Set{String} with 5 elements:
│      "/home/runner/work/PNGFiles.jl/PNGFiles.jl/gen/libpng/libpng_api.jl"
│      "/home/runner/work/PNGFiles.jl/PNGFiles.jl/src/wraphelpers.jl"
│      "/home/runner/work/PNGFiles.jl/PNGFiles.jl/src/io.jl"
│      "/home/runner/work/PNGFiles.jl/PNGFiles.jl/src/utils.jl"
│      "/home/runner/work/PNGFiles.jl/PNGFiles.jl/src/PNGFiles.jl"
└ @ Base loading.jl:2727
```