### PR TITLE
Fix RefArray issue on julia nightly

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -520,7 +520,7 @@ function _write_image(buf::AbstractArray{T,2}, png_ptr::Ptr{Cvoid}, info_ptr::Pt
         ccall(
             (:png_write_image, libpng),
             Cvoid,
-            (Ptr{Cvoid}, Ptr{Ptr{T}}),
+            (Ptr{Cvoid}, Ptr{Ptr{UInt8}}),
             png_ptr,
             map(pointer, eachcol(reinterpret(UInt8, buf))),
         )

--- a/src/io.jl
+++ b/src/io.jl
@@ -527,8 +527,8 @@ function _write_image(buf::AbstractArray{T,2}, png_ptr::Ptr{Cvoid}, info_ptr::Pt
     end
     png_write_end(png_ptr, info_ptr)
 end
-function _write_image(buf::AbstractArray{T,2}, png_ptr::Ptr{Cvoid}, info_ptr::Ptr{Cvoid}) where {T <: AbstractRGB}
-    return _write_image(colorview(buf), png_ptr, info_ptr)
+function _write_image(buf::AbstractArray{T,2}, png_ptr::Ptr{Cvoid}, info_ptr::Ptr{Cvoid}) where {T <: Colorant}
+    return _write_image(rawview(buf), png_ptr, info_ptr)
 end
 
 function _png_check_paletted(image)

--- a/src/io.jl
+++ b/src/io.jl
@@ -527,6 +527,9 @@ function _write_image(buf::AbstractArray{T,2}, png_ptr::Ptr{Cvoid}, info_ptr::Pt
     end
     png_write_end(png_ptr, info_ptr)
 end
+function _write_image(buf::AbstractArray{T,2}, png_ptr::Ptr{Cvoid}, info_ptr::Ptr{Cvoid}) where {T <: AbstractRGB}
+    return _write_image(colorview(buf), png_ptr, info_ptr)
+end
 
 function _png_check_paletted(image)
     palette = image.values

--- a/src/io.jl
+++ b/src/io.jl
@@ -253,7 +253,7 @@ function _load(png_ptr, info_ptr; gamma::Union{Nothing,Float64}=nothing, expand_
 end
 
 function _load!(buffer::Matrix{T}, png_ptr, info_ptr) where T    # separate to support precompilation of permutedims
-    png_read_image(png_ptr, map(pointer, eachcol(rawview(channelview(buffer)))))
+    png_read_image(png_ptr, map(pointer, eachcol(reinterpret(UInt8, buffer))))
     png_read_end(png_ptr, info_ptr)
     png_destroy_read_struct(Ref{Ptr{Cvoid}}(png_ptr), Ref{Ptr{Cvoid}}(info_ptr), C_NULL)
     return permutedims(buffer, (2, 1))
@@ -522,7 +522,7 @@ function _write_image(buf::AbstractArray{T,2}, png_ptr::Ptr{Cvoid}, info_ptr::Pt
             Cvoid,
             (Ptr{Cvoid}, Ptr{Ptr{T}}),
             png_ptr,
-            map(pointer, eachcol(rawview(channelview(buf)))),
+            map(pointer, eachcol(reinterpret(UInt8, buf))),
         )
     end
     png_write_end(png_ptr, info_ptr)

--- a/src/io.jl
+++ b/src/io.jl
@@ -253,7 +253,7 @@ function _load(png_ptr, info_ptr; gamma::Union{Nothing,Float64}=nothing, expand_
 end
 
 function _load!(buffer::Matrix{T}, png_ptr, info_ptr) where T    # separate to support precompilation of permutedims
-    png_read_image(png_ptr, map(pointer, eachcol(buffer)))
+    png_read_image(png_ptr, map(pointer, eachcol(rawview(channelview(buffer)))))
     png_read_end(png_ptr, info_ptr)
     png_destroy_read_struct(Ref{Ptr{Cvoid}}(png_ptr), Ref{Ptr{Cvoid}}(info_ptr), C_NULL)
     return permutedims(buffer, (2, 1))
@@ -522,13 +522,10 @@ function _write_image(buf::AbstractArray{T,2}, png_ptr::Ptr{Cvoid}, info_ptr::Pt
             Cvoid,
             (Ptr{Cvoid}, Ptr{Ptr{T}}),
             png_ptr,
-            map(pointer, eachcol(buf)),
+            map(pointer, eachcol(rawview(channelview(buf)))),
         )
     end
     png_write_end(png_ptr, info_ptr)
-end
-function _write_image(buf::AbstractArray{T,2}, png_ptr::Ptr{Cvoid}, info_ptr::Ptr{Cvoid}) where {T <: Colorant}
-    return _write_image(rawview(buf), png_ptr, info_ptr)
 end
 
 function _png_check_paletted(image)

--- a/src/io.jl
+++ b/src/io.jl
@@ -253,7 +253,7 @@ function _load(png_ptr, info_ptr; gamma::Union{Nothing,Float64}=nothing, expand_
 end
 
 function _load!(buffer::Matrix{T}, png_ptr, info_ptr) where T    # separate to support precompilation of permutedims
-    png_read_image(png_ptr, map(pointer, eachcol(reinterpret(UInt8, buffer))))
+    png_read_image(png_ptr, map(a -> Ptr{Ptr{UInt8}}(pointer(a)), eachcol(buffer)))
     png_read_end(png_ptr, info_ptr)
     png_destroy_read_struct(Ref{Ptr{Cvoid}}(png_ptr), Ref{Ptr{Cvoid}}(info_ptr), C_NULL)
     return permutedims(buffer, (2, 1))

--- a/src/io.jl
+++ b/src/io.jl
@@ -253,7 +253,7 @@ function _load(png_ptr, info_ptr; gamma::Union{Nothing,Float64}=nothing, expand_
 end
 
 function _load!(buffer::Matrix{T}, png_ptr, info_ptr) where T    # separate to support precompilation of permutedims
-    png_read_image(png_ptr, map(a -> Ptr{Ptr{UInt8}}(pointer(a)), eachcol(buffer)))
+    png_read_image(png_ptr, map(a -> Ptr{UInt8}(pointer(a)), eachcol(buffer)))
     png_read_end(png_ptr, info_ptr)
     png_destroy_read_struct(Ref{Ptr{Cvoid}}(png_ptr), Ref{Ptr{Cvoid}}(info_ptr), C_NULL)
     return permutedims(buffer, (2, 1))
@@ -522,7 +522,7 @@ function _write_image(buf::AbstractArray{T,2}, png_ptr::Ptr{Cvoid}, info_ptr::Pt
             Cvoid,
             (Ptr{Cvoid}, Ptr{Ptr{UInt8}}),
             png_ptr,
-            map(pointer, eachcol(reinterpret(UInt8, buf))),
+            map(a -> Ptr{UInt8}(pointer(a)), eachcol(buf)),
         )
     end
     png_write_end(png_ptr, info_ptr)


### PR DESCRIPTION
Fixes https://github.com/JuliaIO/PNGFiles.jl/issues/74

try fix
```
  TypeError: in RefArray, in A, expected A<:(AbstractArray{Ptr{UInt8}}), got Type{Vector{Ptr{RGBA{N0f16}}}}
  Stacktrace:
    [1] Ref{Ptr{UInt8}}(a::Vector{Ptr{RGBA{N0f16}}})
      @ Base ./refpointer.jl:158
    [2] cconvert(::Type{Ptr{Ptr{UInt8}}}, a::Vector{Ptr{RGBA{N0f16}}})
      @ Base ./refpointer.jl:176
    [3] png_read_image(png_ptr::Ptr{Nothing}, image::Vector{Ptr{RGBA{N0f16}}})
      @ PNGFiles ~/work/PNGFiles.jl/PNGFiles.jl/gen/libpng/libpng_api.jl:558
    [4] _load!(buffer::Matrix{RGBA{N0f16}}, png_ptr::Ptr{Nothing}, info_ptr::Ptr{Nothing})
      @ PNGFiles ~/work/PNGFiles.jl/PNGFiles.jl/src/io.jl:256
    [5] #invokelatest#2
      @ ./essentials.jl:950 [inlined]
    [6] invokelatest
      @ ./essentials.jl:947 [inlined]
    [7] _load(png_ptr::Ptr{Nothing}, info_ptr::Ptr{Nothing}; gamma::Nothing, expand_paletted::Bool, background::Bool)
      @ PNGFiles ~/work/PNGFiles.jl/PNGFiles.jl/src/io.jl:243
    [8] _load
      @ ~/work/PNGFiles.jl/PNGFiles.jl/src/io.jl:105 [inlined]
    [9] #4
      @ ~/work/PNGFiles.jl/PNGFiles.jl/src/io.jl:88 [inlined]
   [10] maybe_lock
      @ ~/work/PNGFiles.jl/PNGFiles.jl/src/io.jl:62 [inlined]
   [11] load(s::IOBuffer; gamma::Nothing, expand_paletted::Bool, background::Bool)
      @ PNGFiles ~/work/PNGFiles.jl/PNGFiles.jl/src/io.jl:80
   [12] load(s::IOBuffer)
      @ PNGFiles ~/work/PNGFiles.jl/PNGFiles.jl/src/io.jl:73
   [13] macro expansion
      @ ~/work/PNGFiles.jl/PNGFiles.jl/test/test_io.jl:16 [inlined]
   [14] macro expansion
      @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.11/Test/src/Test.jl:676 [inlined]
   [15] macro expansion
      @ ~/work/PNGFiles.jl/PNGFiles.jl/test/test_io.jl:12 [inlined]
   [16] macro expansion
      @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.11/Test/src/Test.jl:1598 [inlined]
   [17] top-level scope
      @ ~/work/PNGFiles.jl/PNGFiles.jl/test/test_io.jl:12
```