### PR TITLE
Fix handling of non-ASCII file paths on Windows for PNG read/write operations

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -360,6 +360,7 @@ function save(
     T,
     S<:Union{AbstractMatrix{T},AbstractArray{T,3}}
 }
+    occursin('\0', fpath) && throw(ArgumentError("fpath contains a null character"))
     @assert Z_DEFAULT_STRATEGY <= compression_strategy <= Z_FIXED
     @assert Z_NO_COMPRESSION <= compression_level <= Z_BEST_COMPRESSION
     @assert 2 <= ndims(image) <= 3
@@ -367,9 +368,7 @@ function save(
 
     # Non-ASCII characters require the wide-string Windows API
     fp = if Sys.iswindows()
-        wfpath = transcode(UInt16, fpath * "\0")
-        ccall(:_wfopen, Ptr{Cvoid}, (Ptr{UInt16}, Ptr{UInt16}),
-              wfpath, transcode(UInt16, "wb\0"))
+        ccall(:_wfopen, Ptr{Cvoid}, (Cwstring, Cwstring), fpath, "wb")
     else
         ccall(:fopen, Ptr{Cvoid}, (Cstring, Cstring), fpath, "wb")
     end

--- a/src/io.jl
+++ b/src/io.jl
@@ -365,7 +365,13 @@ function save(
     @assert 2 <= ndims(image) <= 3
     @assert size(image, 3) <= 4
 
-    fp = ccall(:fopen, Ptr{Cvoid}, (Cstring, Cstring), fpath, "wb")
+    fp = if Sys.iswindows()
+        wfpath = transcode(UInt16, fpath * "\0")
+        ccall(:_wfopen, Ptr{Cvoid}, (Ptr{UInt16}, Ptr{UInt16}),
+              wfpath, transcode(UInt16, "wb\0"))
+    else
+        ccall(:fopen, Ptr{Cvoid}, (Cstring, Cstring), fpath, "wb")
+    end
     fp == C_NULL && error("Could not open $(fpath) for writing")
 
     png_ptr = create_write_struct()

--- a/src/io.jl
+++ b/src/io.jl
@@ -365,6 +365,7 @@ function save(
     @assert 2 <= ndims(image) <= 3
     @assert size(image, 3) <= 4
 
+    # Non-ASCII characters require the wide-string Windows API
     fp = if Sys.iswindows()
         wfpath = transcode(UInt16, fpath * "\0")
         ccall(:_wfopen, Ptr{Cvoid}, (Ptr{UInt16}, Ptr{UInt16}),

--- a/src/wraphelpers.jl
+++ b/src/wraphelpers.jl
@@ -29,16 +29,20 @@ function get_libpng_version()
 end
 
 function open_png(filename::String)
-    fp = ccall(:fopen, Ptr{Cvoid}, (Cstring, Cstring), filename, "rb")
+    fp = if Sys.iswindows()
+        wfilename = transcode(UInt16, filename * "\0")
+        ccall(:_wfopen, Ptr{Cvoid}, (Ptr{UInt16}, Ptr{UInt16}),
+              wfilename, transcode(UInt16, "rb\0"))
+    else
+        ccall(:fopen, Ptr{Cvoid}, (Cstring, Cstring), filename, "rb")
+    end
     fp == C_NULL && error("Failed to open $filename")
-
     header = zeros(UInt8, PNG_BYTES_TO_CHECK)
-    header_size = ccall(:fread, Csize_t, (Ptr{UInt8}, Cint, Cint, Ptr{Cvoid}), header, 1, PNG_BYTES_TO_CHECK, fp)
+    header_size = ccall(:fread, Csize_t, (Ptr{UInt8}, Cint, Cint, Ptr{Cvoid}),
+                        header, 1, PNG_BYTES_TO_CHECK, fp)
     header_size != 8 && error("Failed to read header from $filename")
-
     is_png = png_sig_cmp(header, 0, PNG_BYTES_TO_CHECK)
     is_png != 0 && error("File $filename is not a png file")
-
     return fp
 end
 

--- a/src/wraphelpers.jl
+++ b/src/wraphelpers.jl
@@ -29,10 +29,9 @@ function get_libpng_version()
 end
 
 function open_png(filename::String)
+    occursin('\0', filename) && throw(ArgumentError("filename contains a null character"))
     fp = if Sys.iswindows()
-        wfilename = transcode(UInt16, filename * "\0")
-        ccall(:_wfopen, Ptr{Cvoid}, (Ptr{UInt16}, Ptr{UInt16}),
-              wfilename, transcode(UInt16, "rb\0"))
+        ccall(:_wfopen, Ptr{Cvoid}, (Cwstring, Cwstring), filename, "rb")
     else
         ccall(:fopen, Ptr{Cvoid}, (Cstring, Cstring), filename, "rb")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,6 +59,18 @@ ensure_imagemagick()
     include("test_invalid_inputs.jl")
     include("test_images_with_background.jl")
     include("test_io.jl")
+    @testset "Non-ASCII paths" begin
+        mktempdir() do temp_root
+            unicode_dir = joinpath(temp_root, "áéüñ")
+            mkpath(unicode_dir)
+
+            image = rand(Gray{N0f8}, 4, 4)
+            file_path = joinpath(unicode_dir, "test.png")
+
+            PNGFiles.save(file_path, image)
+            @test PNGFiles.load(file_path) == image
+        end
+    end
     include("test_various_array_types.jl")
     include("test_dpi.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,18 +59,7 @@ ensure_imagemagick()
     include("test_invalid_inputs.jl")
     include("test_images_with_background.jl")
     include("test_io.jl")
-    @testset "Non-ASCII paths" begin
-        mktempdir() do temp_root
-            unicode_dir = joinpath(temp_root, "áéüñ")
-            mkpath(unicode_dir)
-
-            image = rand(Gray{N0f8}, 4, 4)
-            file_path = joinpath(unicode_dir, "test.png")
-
-            PNGFiles.save(file_path, image)
-            @test PNGFiles.load(file_path) == image
-        end
-    end
+    include("test_non_ascii_paths.jl")
     include("test_various_array_types.jl")
     include("test_dpi.jl")
 end

--- a/test/test_invalid_inputs.jl
+++ b/test/test_invalid_inputs.jl
@@ -24,6 +24,12 @@ warn_background_arguments = [
 ]
 
 @testset "Invalid inputs" begin
+    @testset "File paths" begin
+        nul_path = "bad\0path.png"
+        @test_throws ArgumentError PNGFiles.load(nul_path)
+        @test_throws ArgumentError PNGFiles.save(nul_path, rand(4, 4))
+    end
+
     @testset "Dimensionality" begin
         for (case, exception, image) in invalid_imgs
             @testset "$(case) throws" begin

--- a/test/test_non_ascii_paths.jl
+++ b/test/test_non_ascii_paths.jl
@@ -1,0 +1,12 @@
+@testset "Non-ASCII paths" begin
+    mktempdir() do temp_root
+        unicode_dir = joinpath(temp_root, "áéüñ")
+        mkpath(unicode_dir)
+
+        image = rand(Gray{N0f8}, 4, 4)
+        file_path = joinpath(unicode_dir, "test.png")
+
+        PNGFiles.save(file_path, image)
+        @test PNGFiles.load(file_path) == image
+    end
+end


### PR DESCRIPTION
**Problem**
PNGFiles could not reliably read or write PNG files on Windows when the file path contained non-ASCII characters, because the code used `fopen` instead of the wide-character Windows API. That meant paths with accented or otherwise non-ASCII names could fail even though they should be valid on Windows.

This issue is causing https://github.com/MakieOrg/Makie.jl/issues/4749.

**Changes**
The core fix switches the file open calls in io.jl to `_wfopen` on Windows so Unicode file paths are handled correctly for both reading and writing. I also added a test in runtests.jl that saves a small PNG into a temporary Unicode-named directory and loads it back to verify round-trip correctness on all platforms.