### PR TITLE
Enable skipped Windows tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ open(DEBUG_FILE, "w") do f
     write(f, "```\n")
 end
 function _add_debugging_entry(fpath, case, imdiff_val=missing)
-    apath = joinpath(@__DIR__, abspath(fpath))
+    apath = abspath(fpath)
     open(DEBUG_FILE, "a") do f
         write(f, "\n\n")
         write(f, "# $(case) ############################################################\n")

--- a/test/test_pngsuite.jl
+++ b/test/test_pngsuite.jl
@@ -50,7 +50,7 @@ end
 parse_pngsuite(x::Symbol) = parse_pngsuite(String(x))
 
 @testset "PngSuite" begin
-    for fpath in glob(joinpath("./**/$(PNG_SUITE_DIR)", "[!x]*[!_new][!_new_im].png"))
+    for fpath in glob("./**/$(PNG_SUITE_DIR)/[!x]*[!_new][!_new_im].png")
         case = last(splitpath(fpath))
         case_info = parse_pngsuite(case)
         C = case_info.color_type
@@ -102,7 +102,7 @@ parse_pngsuite(x::Symbol) = parse_pngsuite(String(x))
 
     ## TODO: Malformed pngs that should error. This throws `signal (6): Aborted` since we
     ## don't work with `png_jmpbuf` properly.
-    # for fpath in glob(joinpath("./**/$(PNG_SUITE_DIR)", "[x]*.png"))
+    # for fpath in glob("./**/$(PNG_SUITE_DIR)/[x]*.png")
     #     case = splitpath(fpath)[end]
     #     @info case
     #     @testset "$(case)" begin
@@ -111,7 +111,7 @@ parse_pngsuite(x::Symbol) = parse_pngsuite(String(x))
     # end
 
     @testset "Background chunk" begin
-        for fpath in glob(joinpath("./**/$(PNG_SUITE_DIR)", "bg*[!_new][!_new_im].png"))
+        for fpath in glob("./**/$(PNG_SUITE_DIR)/bg*[!_new][!_new_im].png")
             case = last(splitpath(fpath))
             bg_color_type = case[3]
             @testset "$(case)" begin


### PR DESCRIPTION
As noted in the README of https://github.com/vtjnash/Glob.jl the "the path separator in a glob pattern is always `/` and the escape character is always `\`"