### PR TITLE
create fileio extension for integration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,8 +11,15 @@ IndirectArrays = "9b13fd28-a010-5f03-acff-a1bbcff69959"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 libpng_jll = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
 
+[weakdeps]
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+
+[extensions]
+PNGFilesFileIOExt = "FileIO"
+
 [compat]
 CEnum = "0.2, 0.3, 0.4, 0.5"
+FileIO = "1"
 ImageCore = "0.8, 0.9, 0.10"
 ImageMagick = "1.4"
 IndirectArrays = "0.5, 1.0"
@@ -23,6 +30,7 @@ libpng_jll = "1.6.37"
 [extras]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 ImageMagick_jll = "c73af94c-d91f-53ed-93a7-00f77d67a9d7"
@@ -34,4 +42,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["AxisArrays", "Downloads", "Glob", "ImageMagick", "ImageMagick_jll", "Logging", "PaddedViews", "Random", "Tar", "Test", "TestImages"]
+test = ["AxisArrays", "Downloads", "FileIO", "Glob", "ImageMagick", "ImageMagick_jll", "Logging", "PaddedViews", "Random", "Tar", "Test", "TestImages"]

--- a/ext/PNGFilesFileIOExt.jl
+++ b/ext/PNGFilesFileIOExt.jl
@@ -1,0 +1,31 @@
+module PNGFilesFileIOExt
+
+using PNGFiles
+using FileIO: File, Stream, DataFormat, stream
+
+# `PNGFiles.load` already returns the canonical PNG result (an `Array` for most
+# images and an `IndirectArray` for paletted ones), so no extra canonicalization
+# is needed here — we simply forward to it.
+function PNGFiles.fileio_load(f::File{DataFormat{:PNG}}; kwargs...)
+    return PNGFiles.load(f.filename; kwargs...)
+end
+
+function PNGFiles.fileio_load(s::Stream{DataFormat{:PNG}}; kwargs...)
+    return PNGFiles.load(stream(s); kwargs...)
+end
+
+function PNGFiles.fileio_save(f::File{DataFormat{:PNG}}, image::S; kwargs...) where {T, S<:Union{AbstractMatrix, AbstractArray{T,3}}}
+    return PNGFiles.save(f.filename, image; kwargs...)
+end
+
+function PNGFiles.fileio_save(s::Stream{DataFormat{:PNG}}, image::S; permute_horizontal=false, mapi=identity, kwargs...) where {T, S<:Union{AbstractMatrix, AbstractArray{T,3}}}
+    imgout = map(mapi, image)
+    if permute_horizontal
+        perm = ndims(imgout) == 2 ? (2, 1) : ndims(imgout) == 3 ? (2, 1, 3) : error("$(ndims(imgout)) dims array is not supported")
+        return PNGFiles.save(stream(s), PermutedDimsArray(imgout, perm); kwargs...)
+    else
+        return PNGFiles.save(stream(s), imgout; kwargs...)
+    end
+end
+
+end # module

--- a/src/PNGFiles.jl
+++ b/src/PNGFiles.jl
@@ -21,6 +21,13 @@ include("wraphelpers.jl")
 include("utils.jl")
 include("io.jl")
 
+# FileIO.jl integration. The methods are provided by the `PNGFilesFileIOExt`
+# extension (loaded when FileIO is available). These stubs make `fileio_load`
+# and `fileio_save` resolvable as `PNGFiles.fileio_load`/`PNGFiles.fileio_save`,
+# which is how FileIO locates the loader/saver registered for `format"PNG"`.
+function fileio_load end
+function fileio_save end
+
 function __init__()
     readcallback_c[] = @cfunction(_readcallback, Cvoid, (png_structp, png_bytep, png_size_t));
     readcallback_iobuffer_c[] = @cfunction(_readcallback_iobuffer, Cvoid, (png_structp, png_bytep, png_size_t));


### PR DESCRIPTION
It seems like ImageIO and PNGFiles FileIO integration are totally separate.
While not elegant, that means we should be able to release this without any changes to ImageIO.
Will need a PR to FileIO though to directly register PNGFiles as loader.